### PR TITLE
Require feedparser >= 6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 python = "^3.6"
 pelican = "^4.5"
 markdown = {version = "^3.1.1",optional = true}
-feedparser = "^6.0"
+feedparser = ">=6.0"
 
 [tool.poetry.dev-dependencies]
 pelican = { git = "https://github.com/getpelican/pelican.git" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 python = "^3.6"
 pelican = "^4.5"
 markdown = {version = "^3.1.1",optional = true}
-feedparser = "^5.2"
+feedparser = "^6.0"
 
 [tool.poetry.dev-dependencies]
 pelican = { git = "https://github.com/getpelican/pelican.git" }


### PR DESCRIPTION
Python 3.9 is out and `base64.decodestring` used in old version of feedparser is removed.

```
>>> from pelican.plugins import webring                                                                                                     
Traceback (most recent call last):                                                                                                          
  File "<stdin>", line 1, in <module>                                                                                                       
  File "/home/nicolas/Sources/git.sr.ht/~nka/blog/.venv/lib/python3.9/site-packages/pelican/plugins/webring/__init__.py", line 1, in <module
>                                                                                                                                           
    from .webring import *  # NOQA                                                                                                          
  File "/home/nicolas/Sources/git.sr.ht/~nka/blog/.venv/lib/python3.9/site-packages/pelican/plugins/webring/webring.py", line 17, in <module
>                                                                                                                                           
    import feedparser                                                                                                                       
  File "/home/nicolas/Sources/git.sr.ht/~nka/blog/.venv/lib/python3.9/site-packages/feedparser.py", line 93, in <module>
    _base64decode = getattr(base64, 'decodebytes', base64.decodestring)
AttributeError: module 'base64' has no attribute 'decodestring'
```

Version 6.0 has the required fix: https://github.com/kurtmckee/feedparser/pull/206