### PR TITLE
Fetch feeds in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ venv
 .venv
 tags
 .python-version
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+
+# Unit test / coverage reports
+.pytest_cache/

--- a/pelican/plugins/webring/test_webring.py
+++ b/pelican/plugins/webring/test_webring.py
@@ -9,12 +9,12 @@ import os
 from types import SimpleNamespace
 import unittest
 
-import webring
-
 from pelican import utils
 from pelican.generators import Generator
 from pelican.settings import DEFAULT_CONFIG
 from pelican.tests.support import get_context, get_settings, module_exists
+
+import webring
 
 
 class NullGenerator(Generator):

--- a/pelican/plugins/webring/test_webring.py
+++ b/pelican/plugins/webring/test_webring.py
@@ -9,12 +9,12 @@ import os
 from types import SimpleNamespace
 import unittest
 
+import webring
+
 from pelican import utils
 from pelican.generators import Generator
 from pelican.settings import DEFAULT_CONFIG
 from pelican.tests.support import get_context, get_settings, module_exists
-
-import webring
 
 
 class NullGenerator(Generator):

--- a/pelican/plugins/webring/webring.py
+++ b/pelican/plugins/webring/webring.py
@@ -92,14 +92,16 @@ def fetch_feeds(generators):
     def fetch(feed_url):
         feed_html = get_feed_html(feed_url)
         if feed_html:
-            fetched_articles.extend(get_feed_articles(feed_html, feed_url))
+            return get_feed_articles(feed_html, feed_url)
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
         futures = []
         for feed_url in settings[WEBRING_FEED_URLS_STR]:
             futures.append(executor.submit(fetch, feed_url=feed_url))
         for future in concurrent.futures.as_completed(futures):
-            future.result()
+            articles = future.result()
+            if articles is not None:
+                fetched_articles.extend(articles)
 
     fetched_articles = sorted(fetched_articles, key=attrgetter("date"), reverse=True)
 

--- a/pelican/plugins/webring/webring.py
+++ b/pelican/plugins/webring/webring.py
@@ -5,8 +5,8 @@ Webring plugin for Pelican
 A plugin to create a webring or feed aggregation in your web site from a list
 of web feeds.
 """
-from logging import warning
 import concurrent.futures
+from logging import warning
 from operator import attrgetter
 import re
 from urllib.error import URLError


### PR DESCRIPTION
Fixes #9 with a backward compatible solution using the underrated `concurrent.futures.ThreadPoolExecutor`.

I'm not really sure how to add unit tests to test this. 

### To test this locally :
```
# change the value on the max_workers: 1, then 100
with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
```

 ```
 # add a test like this one
 def test_parrallel_fetch(self):
        self.set_feeds(["https://httpbin.org/delay/2" for _ in range(0, 10)])
        webring.fetch_feeds(self.generators)
 ```
 
 Look at how much time it takes to run the tests.